### PR TITLE
Update library commit version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+git://github.com/AntagonistHQ/python-api-library@e119989cb0d292a48d4e78a9a75eb1da7da34ff0#egg=kayako&&subdirectory=src
+git+git://github.com/AntagonistHQ/python-api-library@a5a59eed72ace86d2a850d0d03673a7e3fcc6fec#egg=kayako&&subdirectory=src


### PR DESCRIPTION
The specific commit that `requirements.txt` referred to no longer exists. Changing to latest commit.